### PR TITLE
the library hogs my CPU to 100%, even when Kinect isn't connected

### DIFF
--- a/src/Kinect2.cpp
+++ b/src/Kinect2.cpp
@@ -1152,6 +1152,7 @@ void Device::start()
 							process.mNewData	= true;
 						}
 					}
+					std::this_thread::sleep_for(std::chrono::milliseconds(KINECT2_UPDATE_CYCLE));
 				}
 			};
 			break;
@@ -1522,6 +1523,7 @@ void Device::start()
 							process.mNewData	= true;
 						}
 					}
+					std::this_thread::sleep_for(std::chrono::milliseconds(KINECT2_UPDATE_CYCLE));
 				}
 			};
 			break;
@@ -1567,6 +1569,7 @@ void Device::start()
 							process.mNewData	= true;
 						}
 					}
+					std::this_thread::sleep_for(std::chrono::milliseconds(KINECT2_UPDATE_CYCLE));
 				}
 			};
 			break;
@@ -1614,6 +1617,7 @@ void Device::start()
 							process.mNewData	= true;
 						}
 					}
+					std::this_thread::sleep_for(std::chrono::milliseconds(KINECT2_UPDATE_CYCLE));
 				}
 			};
 			break;
@@ -1661,6 +1665,7 @@ void Device::start()
 							process.mNewData	= true;
 						}
 					}
+					std::this_thread::sleep_for(std::chrono::milliseconds(KINECT2_UPDATE_CYCLE));
 				}
 			};
 			break;
@@ -1706,6 +1711,7 @@ void Device::start()
 							process.mNewData	= true;
 						}
 					}
+					std::this_thread::sleep_for(std::chrono::milliseconds(KINECT2_UPDATE_CYCLE));
 				}
 			};
 			break;
@@ -1752,6 +1758,7 @@ void Device::start()
 							process.mNewData			= true;
 						}
 					}
+					std::this_thread::sleep_for(std::chrono::milliseconds(KINECT2_UPDATE_CYCLE));
 				}
 			};
 			break;

--- a/src/Kinect2.h
+++ b/src/Kinect2.h
@@ -57,6 +57,8 @@
 #endif
 #pragma comment( lib, "wbemuuid.lib" )
 
+#define KINECT2_UPDATE_CYCLE 20  /*Proposed value: 20 ms, can be tuned*/
+
 namespace Kinect2 {
 
 class Device;


### PR DESCRIPTION
Proposed fix for the issue "the library hogs my CPU to 100%, even when Kinect isn't connected".
https://github.com/wieden-kennedy/Cinder-KCB2/issues/8

Not a perfect solution, as it may introduce some lag in some cases, but drops the CPU on my machine from 100% to 50%.
