### PR TITLE
New fix proposal for the CPU hitting 100% even when no kinect is connected.

### DIFF
--- a/src/Kinect2.cpp
+++ b/src/Kinect2.cpp
@@ -1116,7 +1116,7 @@ void Device::start()
 			process.mThreadCallback = [ & ]()
 			{
 				while ( process.mRunning ) {
-					if ( process.mNewData || mKinect == KCB_INVALID_HANDLE ) {
+					if (process.mNewData || mKinect == KCB_INVALID_HANDLE || mEventHandlerAudio == nullptr) {
 						this_thread::sleep_for( chrono::milliseconds( kThreadSleepDuration ) );
 						continue;
 					}
@@ -1155,7 +1155,7 @@ void Device::start()
 			process.mThreadCallback = [ & ]()
 			{
 				while ( process.mRunning ) {
-					if ( process.mNewData ) {
+					if (process.mNewData || mEventHandlerBody == nullptr) {
 						this_thread::sleep_for( chrono::milliseconds( kThreadSleepDuration ) );
 						continue;
 					}
@@ -1529,7 +1529,7 @@ void Device::start()
 			process.mThreadCallback = [ & ]()
 			{
 				while ( process.mRunning ) {
-					if ( process.mNewData || mKinect == KCB_INVALID_HANDLE ) {
+					if (process.mNewData || mKinect == KCB_INVALID_HANDLE || mEventHandlerBodyIndex == nullptr) {
 						this_thread::sleep_for( chrono::milliseconds( kThreadSleepDuration ) );
 						continue;
 					}
@@ -1574,7 +1574,7 @@ void Device::start()
 			process.mThreadCallback = [ & ]()
 			{
 				while ( process.mRunning ) {
-					if ( process.mNewData || mKinect == KCB_INVALID_HANDLE ) {
+					if (process.mNewData || mKinect == KCB_INVALID_HANDLE || mEventHandlerColor == nullptr) {
 						this_thread::sleep_for( chrono::milliseconds( kThreadSleepDuration ) );
 						continue;
 					}
@@ -1621,7 +1621,7 @@ void Device::start()
 			process.mThreadCallback = [ & ]()
 			{
 				while ( process.mRunning ) {
-					if ( process.mNewData || mKinect == KCB_INVALID_HANDLE ) {
+					if (process.mNewData || mKinect == KCB_INVALID_HANDLE || mEventHandlerDepth == nullptr) {
 						this_thread::sleep_for( chrono::milliseconds( kThreadSleepDuration ) );
 						continue;
 					}
@@ -1668,7 +1668,7 @@ void Device::start()
 			process.mThreadCallback = [ & ]()
 			{
 				while ( process.mRunning ) {
-					if ( process.mNewData || mKinect == KCB_INVALID_HANDLE ) {
+					if (process.mNewData || mKinect == KCB_INVALID_HANDLE || mEventHandlerInfrared == nullptr) {
 						this_thread::sleep_for( chrono::milliseconds( kThreadSleepDuration ) );
 						continue;
 					}
@@ -1713,7 +1713,7 @@ void Device::start()
 			process.mThreadCallback = [ & ]()
 			{
 				while ( process.mRunning ) {
-					if ( process.mNewData || mKinect == KCB_INVALID_HANDLE ) {
+					if (process.mNewData || mKinect == KCB_INVALID_HANDLE || mEventHandlerInfraredLongExposure == nullptr) {
 						this_thread::sleep_for( chrono::milliseconds( kThreadSleepDuration ) );
 						continue;
 					}


### PR DESCRIPTION
The commit https://github.com/wieden-kennedy/Cinder-KCB2/commit/349bcc2d193c2b9061afaf8723f79afe1a6eb289 didn't completely fix the issue https://github.com/wieden-kennedy/Cinder-KCB2/issues/8
KCB2 is still cranking up my CPU to 100%, even when Kinect isn't connected. 

Proposal to improve the fix, going to sleep also in the case where the application has not connected an event handler.
