### PR TITLE
Combined BodyAndFace2d callback

### DIFF
--- a/src/Kinect2.cpp
+++ b/src/Kinect2.cpp
@@ -1207,8 +1207,7 @@ void Device::start(bool onlyEnabledHandlerThreads)
 		}
 
 		Process& process					= mProcesses.at( (FrameType)frameType );
-		switch ((FrameType)frameType) {
-#if 1
+		switch ( (FrameType)frameType ) {
 		case FrameType_Audio:
 			process.mThreadCallback = [ & ]()
 			{
@@ -1420,7 +1419,6 @@ void Device::start(bool onlyEnabledHandlerThreads)
 				}
 			};
 			break;
-#endif
 		case FrameType_BodyAndFace2d:
 			process.mThreadCallback = [ & ]()
 			{
@@ -1676,7 +1674,6 @@ void Device::start(bool onlyEnabledHandlerThreads)
 				}
 			};
 			break;
-#if 1
 		case FrameType_BodyIndex:
 			process.mThreadCallback = [ & ]()
 			{
@@ -1722,7 +1719,6 @@ void Device::start(bool onlyEnabledHandlerThreads)
 				}
 			};
 			break;
-#endif
 		case FrameType_Color:
 			process.mThreadCallback = [ & ]()
 			{
@@ -1816,7 +1812,6 @@ void Device::start(bool onlyEnabledHandlerThreads)
 				}
 			};
 			break;
-#if 1
 		case FrameType_Face2d:
 			process.mThreadCallback = [ & ]()
 			{
@@ -2087,7 +2082,6 @@ void Device::start(bool onlyEnabledHandlerThreads)
 				}
 			};
 			break;
-#endif
 		case FrameType_Infrared:
 			process.mThreadCallback = [ & ]()
 			{
@@ -2133,7 +2127,6 @@ void Device::start(bool onlyEnabledHandlerThreads)
 				}
 			};
 			break;
-#if 0
 		case FrameType_InfraredLongExposure:
 			process.mThreadCallback = [ & ]()
 			{
@@ -2180,7 +2173,6 @@ void Device::start(bool onlyEnabledHandlerThreads)
 				}
 			};
 			break;
-#endif
 		}
 		process.start();
 	}

--- a/src/Kinect2.h
+++ b/src/Kinect2.h
@@ -421,7 +421,7 @@ public:
 	static DeviceRef									create();
 	~Device();
 	
-	void												start();
+	void												start(bool onlyEnabledHandlerThreads = false);
 	void												stop();
 
 	void												enableFaceMesh( bool enable = true );
@@ -430,6 +430,12 @@ public:
 	bool												isFaceMeshEnabled() const;
 	bool												isHandTrackingEnabled() const;
 	bool												isJointTrackingEnabled() const;
+
+	template<typename T, typename Y>
+	inline void											connectBodyAndFace2dEventHandler(T eventHandler, Y* obj)
+	{
+		connectBodyAndFace2dEventHandler(std::bind(eventHandler, obj, std::placeholders::_1));
+	}
 
 	template<typename T, typename Y>
 	inline void											connectAudioEventHandler( T eventHandler, Y* obj )
@@ -485,6 +491,7 @@ public:
 		connectInfraredLongExposureEventHandler( std::bind( eventHandler, obj, std::placeholders::_1 ) );
 	}
 
+	void												connectBodyAndFace2dEventHandler(const std::function<void(const BodyFrame&, const Face2dFrame&)>& eventHandler);
 	void												connectAudioEventHandler( const std::function<void ( const AudioFrame& )>& eventHandler );
 	void												connectBodyEventHandler( const std::function<void ( const BodyFrame& )>& eventHandler );
 	void												connectBodyIndexEventHandler( const std::function<void ( const BodyIndexFrame& )>& eventHandler );
@@ -495,6 +502,7 @@ public:
 	void												connectInfraredEventHandler( const std::function<void ( const InfraredFrame& )>& eventHandler );
 	void												connectInfraredLongExposureEventHandler( const std::function<void ( const InfraredFrame& )>& eventHandler );
 
+	void												disconnectBodyAndFace2dEventHandler();
 	void												disconnectAudioEventHandler();
 	void												disconnectBodyEventHandler();
 	void												disconnectBodyIndexEventHandler();
@@ -505,6 +513,7 @@ public:
 	void												disconnectInfraredEventHandler();
 	void												disconnectInfraredLongExposureEventHandler();
 
+	bool												isBodyAndFace2dEventHandlerConnected() const;
 	bool												isAudioEventHandlerConnected() const;
 	bool												isBodyEventHandlerConnected() const;
 	bool												isBodyIndexEventHandlerConnected() const;
@@ -530,7 +539,8 @@ protected:
 	enum : size_t
 	{
 		FrameType_Audio,
-		FrameType_Body, 
+		FrameType_Body,
+		FrameType_BodyAndFace2d,
 		FrameType_BodyIndex, 
 		FrameType_Color, 
 		FrameType_Depth, 
@@ -549,7 +559,8 @@ protected:
 	IKinectSensor*										mSensor;
 
 	std::map<FrameType, Process>						mProcesses;
-	
+
+	std::function<void ( const BodyFrame&, const Face2dFrame& )> mEventHandlerBodyAndFace2d;
 	std::function<void ( const AudioFrame& )>			mEventHandlerAudio;
 	std::function<void ( const BodyFrame& )>			mEventHandlerBody;
 	std::function<void ( const BodyIndexFrame& )>		mEventHandlerBodyIndex;
@@ -598,7 +609,8 @@ protected:
 	};
 	typedef std::shared_ptr<FaceData>					FaceDataRef;
 
-	std::list<FaceDataRef>								mFaceData;
+	//std::list<FaceDataRef>								mFaceData;
+	std::vector<FaceDataRef>								mFaceData;
 	float												mFaceShapeDeformations[ FaceShapeDeformations::FaceShapeDeformations_Count ];
 public:
 


### PR DESCRIPTION
Here is an exemple of how Body and Face2d could be parsed in the same thread. Using Body, Face2d and Face3d separately releases the IBodys in which ever thread is first to query, which blocks the other threads trying to access the IBody structures. This solution is of course not complete, and a more  general structure would be needed. Enabling Face3d in combination with BodyAndFace2d, still has the same problems as before, and it's still possible to enable both Body, Face2d and BodyAndFace2d enablers together.

Is it possible that the similar principle goes for image data? Not that they block each other, but they are all updated simultaneusly, and that a combined callback would make sure the user always get synced image data?

I've also added an argument to the start device function, letting the user not start threads that will never be needed in the app.
