### PR TITLE
Update atomic<bool> usage for v140

### DIFF
--- a/src/Kinect2.cpp
+++ b/src/Kinect2.cpp
@@ -742,7 +742,7 @@ const vector<Face3d>& Face3dFrame::getFaces() const
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 Device::Process::Process()
-: mNewData( atomic<bool>( false ) ), mRunning( atomic<bool>( false ) ), 
+: mNewData( false ), mRunning( false ), 
 mThreadCallback( nullptr )
 {
 }
@@ -1164,8 +1164,8 @@ void Device::start()
 
 	uint8_t sensorIsOpen = isSensorOpen();
 	for ( size_t frameType = (size_t)FrameType_Audio; frameType < (size_t)FrameType_InfraredLongExposure; ++frameType ) {
-		mProcesses[ (FrameType)frameType ]	= Process();
-		Process& process					= mProcesses.at( (FrameType)frameType );
+		mProcesses[ (FrameType)frameType ]	= new Process();
+		Process& process					= *mProcesses.at( (FrameType)frameType );
 		switch( (FrameType)frameType ) {
 		case FrameType_Audio:
 			process.mThreadCallback = [ & ]()
@@ -1894,7 +1894,7 @@ void Device::stop()
 	}
 
 	for ( size_t i = (size_t)FrameType_Audio; i < (size_t)FrameType_InfraredLongExposure; ++i ) {
-		mProcesses.at( (FrameType)i ).stop();
+		mProcesses.at( (FrameType)i )->stop();
 	}
 }
 
@@ -1902,7 +1902,7 @@ void Device::update()
 {
 	for ( size_t i = (size_t)FrameType_Audio; i < (size_t)FrameType_InfraredLongExposure; ++i ) {
 		FrameType frameType	= (FrameType)i;
-		Process& process	= mProcesses.at( frameType );
+		Process& process	= *mProcesses.at( frameType );
 		switch( frameType ) {
 		case FrameType_Audio:
 			if ( mEventHandlerAudio != nullptr && process.mNewData ) {

--- a/src/Kinect2.h
+++ b/src/Kinect2.h
@@ -548,7 +548,7 @@ protected:
 	KCBHANDLE											mKinect;
 	IKinectSensor*										mSensor;
 
-	std::map<FrameType, Process>						mProcesses;
+	std::map<FrameType, Process*>						mProcesses;
 	
 	std::function<void ( const AudioFrame& )>			mEventHandlerAudio;
 	std::function<void ( const BodyFrame& )>			mEventHandlerBody;


### PR DESCRIPTION
Without these changes I couldn't get this block to compile on Visual Studio 2015 (v140) on Cinder master branch (0.9.0).

Originally I had the same issue as [this guy](https://github.com/cameron314/concurrentqueue/issues/3), and fixed that by using a different constructor for the `atomic`s. Since there's no default copy constructor, `mProcesses` also has to be changed to be a map of pointers.

I'm relatively new to Cinder and C++, so let me know if this has issues or if I should be fixing compilation problems in a different way.
